### PR TITLE
add NFData instances

### DIFF
--- a/Sound/OSC/Datum.hs
+++ b/Sound/OSC/Datum.hs
@@ -1,4 +1,7 @@
 -- | Data type for OSC datum.
+
+{-# language DeriveGeneric #-}
+
 module Sound.OSC.Datum where
 
 import Data.Int {- base -}
@@ -8,6 +11,8 @@ import Data.Word {- base -}
 import Numeric {- base -}
 import Text.Printf {- base -}
 import Text.Read {- base -}
+import Control.DeepSeq
+import GHC.Generics
 
 import qualified Data.ByteString.Lazy as Lazy {- bytestring -}
 import qualified Data.ByteString.Char8 as Char8 {- bytestring -}
@@ -43,7 +48,9 @@ blob_unpack = Lazy.unpack
 
 -- | Four-byte midi message: port-id, status-byte, data, data.
 data MIDI = MIDI Word8 Word8 Word8 Word8
-    deriving (Eq,Show,Read)
+    deriving (Eq,Show,Read,Generic)
+
+instance NFData MIDI
 
 -- | The basic elements of OSC messages.
 data Datum = Int32 {d_int32 :: Int32}
@@ -54,7 +61,9 @@ data Datum = Int32 {d_int32 :: Int32}
            | Blob {d_blob :: BLOB}
            | TimeStamp {d_timestamp :: Time.Time} -- ie. NTPr
            | Midi {d_midi :: MIDI}
-             deriving (Eq,Read,Show)
+             deriving (Eq,Read,Show,Generic)
+
+instance NFData Datum
 
 -- * Datum types
 

--- a/Sound/OSC/Packet.hs
+++ b/Sound/OSC/Packet.hs
@@ -1,7 +1,12 @@
 -- | Data types for OSC messages, bundles and packets.
+
+{-# language DeriveGeneric #-}
+
 module Sound.OSC.Packet where
 
 import Data.List {- base -}
+import GHC.Generics
+import Control.DeepSeq
 
 import Sound.OSC.Datum {- hosc3 -}
 import Sound.OSC.Time {- hosc3 -}
@@ -16,7 +21,8 @@ type Address_Pattern = String
 -- | An OSC message, an 'Address_Pattern' and a sequence of 'Datum'.
 data Message = Message {messageAddress :: Address_Pattern
                        ,messageDatum :: [Datum]}
-               deriving (Eq,Read,Show)
+               deriving (Eq,Read,Show,Generic)
+instance NFData Message
 
 -- | 'Message' constructor.  It is an 'error' if the 'Address_Pattern'
 -- doesn't conform to the OSC specification.

--- a/hosc.cabal
+++ b/hosc.cabal
@@ -25,7 +25,8 @@ Library
                    data-binary-ieee754,
                    network >= 2.3,
                    time >= 1.5,
-                   transformers
+                   transformers,
+                   deepseq
   GHC-Options:     -Wall -fwarn-tabs
   Exposed-modules: Sound.OSC
                    Sound.OSC.Coding.Byte


### PR DESCRIPTION
These instances are convenient for https://github.com/tidalcycles/Tidal/issues/606#issuecomment-633662759

We could put them in Tidal but then they'd be orphans. They might be useful in general.

Also for the remaining types of this module? (Bundle, Packet, TCP, UDP)

(alternative: make all constructor arguments strict?)
