### PR TITLE
extended typeclasses to incorporate either decoding osc

### DIFF
--- a/Sound/Osc/Transport/Fd.hs
+++ b/Sound/Osc/Transport/Fd.hs
@@ -4,6 +4,7 @@ module Sound.Osc.Transport.Fd where
 import Control.Exception {- base -}
 import Data.List {- base -}
 import Data.Maybe {- base -}
+import qualified Data.ByteString.Lazy as ByteString.Lazy
 
 import Sound.Osc.Datum {- hosc -}
 import Sound.Osc.Packet {- hosc -}
@@ -16,6 +17,9 @@ class Transport t where
 
   -- | Receive and decode an Osc packet.
   recvPacket :: t -> IO (PacketOf Message)
+
+  -- | Receive and either decode an Osc packet.
+  recvPacketOrFail :: t -> IO (Either ByteString.Lazy.ByteString Packet)
 
   -- | Close an existing connection.
   close :: t -> IO ()

--- a/Sound/Osc/Transport/Fd/Socket.hs
+++ b/Sound/Osc/Transport/Fd/Socket.hs
@@ -34,5 +34,7 @@ instance Fd.Transport OscSocket where
   sendPacket (OscUdpSocket fd) = Fd.Udp.udp_send_packet fd
   recvPacket (OscTcpSocket fd) = Fd.Tcp.tcp_recv_packet fd
   recvPacket (OscUdpSocket fd) = Fd.Udp.udp_recv_packet fd
+  recvPacketOrFail (OscTcpSocket fd) = Fd.Tcp.tcp_recv_packet_or_fail fd
+  recvPacketOrFail (OscUdpSocket fd) = Fd.Udp.udp_recv_packet_or_fail fd
   close (OscTcpSocket fd) = Fd.Tcp.tcp_close fd
   close (OscUdpSocket fd) = Fd.Udp.udp_close fd

--- a/Sound/Osc/Transport/Fd/Tcp.hs
+++ b/Sound/Osc/Transport/Fd/Tcp.hs
@@ -34,6 +34,12 @@ tcp_recv_packet (Tcp fd) = do
   b1 <- ByteString.Lazy.hGet fd (Convert.word32_to_int (Byte.decode_word32 b0))
   return (Decode.Binary.decodePacket b1)
 
+tcp_recv_packet_or_fail :: Tcp -> IO (Either ByteString.Lazy.ByteString Packet.Packet)
+tcp_recv_packet_or_fail (Tcp fd) = do
+  b0 <- ByteString.Lazy.hGet fd 4
+  b1 <- ByteString.Lazy.hGet fd (Convert.word32_to_int (Byte.decode_word32 b0))
+  return (Decode.Binary.eitherDecodePacket b1)
+
 -- | Close Tcp.
 tcp_close :: Tcp -> IO ()
 tcp_close = Io.hClose . tcpHandle
@@ -42,6 +48,7 @@ tcp_close = Io.hClose . tcpHandle
 instance Fd.Transport Tcp where
   sendPacket = tcp_send_packet
   recvPacket = tcp_recv_packet
+  recvPacketOrFail = tcp_recv_packet_or_fail
   close = tcp_close
 
 -- | Bracket Tcp communication.

--- a/Sound/Osc/Transport/Fd/Udp.hs
+++ b/Sound/Osc/Transport/Fd/Udp.hs
@@ -6,6 +6,7 @@ import Control.Monad {- base -}
 import Data.Bifunctor {- base -}
 
 import qualified Data.ByteString as B {- bytestring -}
+import qualified Data.ByteString.Lazy.Char8 as ByteString.Lazy
 import qualified Network.Socket as N {- network -}
 import qualified Network.Socket.ByteString as C {- network -}
 
@@ -40,6 +41,9 @@ udp_send_packet udp = udp_sendAll_data udp . Builder.encodePacket_strict
 udp_recv_packet :: Udp -> IO (Packet.PacketOf Packet.Message)
 udp_recv_packet (Udp fd) = fmap Binary.decodePacket_strict (C.recv fd 8192)
 
+udp_recv_packet_or_fail :: Udp -> IO (Either ByteString.Lazy.ByteString Packet.Packet)
+udp_recv_packet_or_fail (Udp fd) = Binary.eitherDecodePacket . B.fromStrict <$> C.recv fd 8192
+
 -- | Close Udp.
 udp_close :: Udp -> IO ()
 udp_close (Udp fd) = N.close fd
@@ -48,6 +52,7 @@ udp_close (Udp fd) = N.close fd
 instance Fd.Transport Udp where
   sendPacket = udp_send_packet
   recvPacket = udp_recv_packet
+  recvPacketOrFail = udp_recv_packet_or_fail
   close = udp_close
 
 -- | Bracket Udp communication.


### PR DESCRIPTION
Hey Rohan, we had a mail chat about recursive OSC messages and how they could cause trouble and the program to halt. You were so kind to implement a type parameter, however I thought it might be beneficial to have an easy to use extra option to receive recursively packed or probably damaged OSC messages without a full program halt; using an eitherDecode function.
What do you think about it?

Kind regards
Sven